### PR TITLE
Update `date.past` params format

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,8 @@ const popularTrips = useFakeData({
 |                       |                   |                       | multipleOf: number        |
 |                       |                   |                       | }                         |
 | array.element         | T                 | array<T>              | array<T>                  |
-| date.past             | string            | object&string         | {                         |
+| date.past             | string            | object                | {                         |
 |                       |                   |                       | years?: number            |
 |                       |                   |                       | refDate?: string | number |
-|                       |                   |                       | } & separator:string      |
+|                       |                   |                       | separator: string         |
+|                       |                   |                       | }                         |

--- a/src/dataTypes/date.ts
+++ b/src/dataTypes/date.ts
@@ -3,11 +3,12 @@ import { faker } from '@faker-js/faker';
 interface pastParams {
     years?: number;
     refDate?: string | number;
+    separator: string;
 }
 
 class Date {
-    past(params: pastParams = {}, separator: string = '/'): string {
-        return faker.date.past(params).toLocaleDateString('en-UK').replaceAll('/', separator);
+    past(params: pastParams = {separator:'/'}): string {
+        return faker.date.past(params).toLocaleDateString('en-UK').replaceAll('/', params['separator'] ?? '/');
     }
 }
 

--- a/src/dataTypes/date.ts
+++ b/src/dataTypes/date.ts
@@ -7,7 +7,7 @@ interface pastParams {
 }
 
 class Date {
-    past(params: pastParams = {separator:'/'}): string {
+    past(params: pastParams = {separator: '/'}): string {
         return faker.date.past(params).toLocaleDateString('en-UK').replaceAll('/', params['separator'] ?? '/');
     }
 }

--- a/tests/unit/dataTypes/date.test.ts
+++ b/tests/unit/dataTypes/date.test.ts
@@ -33,12 +33,12 @@ describe('date data type', () => {
         });
 
         test('generates valid data with customized separator', () => {
-            const past = date.past({years: 3}, '-');
+            const past = date.past({years: 3, separator: '-'});
             const dateFormat = /^(\d{1,2})-(\d{1,2})-(\d{4})$/g;
 
             expect(dateFormat.test(past)).toBeTruthy();
             expect(typeof past).toBe('string');
-            expect(inPast(past)).toBeTruthy();
+            expect(inPast(past, '-')).toBeTruthy();
             expect(past.match(/\//g) || []).toHaveLength(0);
             expect(past.match(/-/g) || []).toHaveLength(2);
         });


### PR DESCRIPTION
Make `date.past` accepts one single object parameter.